### PR TITLE
Add ZSH Support

### DIFF
--- a/warp
+++ b/warp
@@ -42,7 +42,13 @@ warp() {
   local COMMAND="$(awk -v cmd=$SSH 'BEGIN {printf cmd} {printf " " $1} END { print "" }' "$TARGET")"
 
   # add the command to the bash history as if we had typed it, will only work if sourced
-  eval "history -s $COMMAND"
+  # Determine which history command to use based on shell
+  if [ -n "$BASH_VERSION" ]; then
+    eval "history -s $COMMAND"
+  elif [ -n "$ZSH_VERSION" ]; then
+    eval "print -s $COMMAND"
+  fi
+
   # run the command
   eval $COMMAND
 }
@@ -50,5 +56,7 @@ warp() {
 # allow warp to be sourced without running
 if [[ $_ == $0 ]]; then
   warp
+else
+  # Hide warp from history if using zsh and setopt histignorespace
+  alias warp=" warp"
 fi
-


### PR DESCRIPTION
The current version of the script dies when sourced in zsh during the awk command. 

```
warp:local:38: not an identifier: 192.168.1.201
```

This branch fixes the error by making strings explicit.
The ZSH history option is also added in this branch.

Tested as both a sourced script and a stand-alone script in both bash and zsh.
