### PR TITLE
support the ssh port is not default 22, use # and -- start a comment

### DIFF
--- a/warp
+++ b/warp
@@ -37,10 +37,11 @@ warp() {
       SSH=${MULTISSH:-csshX}
     fi
   fi
-  if [ "$(expr substr $(uname -s) 1 6)" == "Darwin" ]; then
+  _uname=$(uname -s)
+  if [ "${_uname:0:6}" == "Darwin" ]; then
     sed -i "" "s/#.*$//g" ~/.picked
     sed -i "" "s/\-\-.*$//g" ~/.picked
-  elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  elif [ "${_uname:0:5}" == "Linux" ]; then
     sed -i "s/#.*$//g" ~/.picked
     sed -i "s/\-\-.*$//g" ~/.picked
   fi


### PR DESCRIPTION
First of all, a very awesome tool, I like it. thanks!

this patch compatible with mac and ubuntu.

in ~/.warp like this:
hellow@1.2.3.4 -p2200 # this is comment
world@5.6.7.8 -p2200 -i ~/.ssh/id_rsa -- this is comment

after selected in ~/.picked like:
hellow@1.2.3.4 -p2200
or like:
world@5.6.7.8 -p2200 -i ~/.ssh/id_rsa
