### PR TITLE
added one argument to command

### DIFF
--- a/warp
+++ b/warp
@@ -37,7 +37,7 @@ warp() {
       SSH=${MULTISSH:-csshX}
     fi
   fi
-  local COMMAND="$(awk -v cmd=$SSH 'BEGIN {printf cmd} {printf " " $1} END { print "" }' "$TARGET")"
+  local COMMAND="$(awk -v cmd=$SSH 'BEGIN {printf cmd} {printf " " $1 " " $2} END { print "" }' "$TARGET")"
 
   # add the command to the bash history as if we had typed it, will only work if sourced
   # Determine which history command to use based on shell


### PR DESCRIPTION
to be able to specify a SSH port number to connect to. 
One can add a second column to a .warp file and write a TCP port number for SSH if it differs from standard value (which is 22 by default)
