### PR TITLE
Allow an alternate warp file by passing it as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ is useful if you want to SSH to multiple hosts that are not on lines following
 each other: just slice and dice the file, put the lines together, add or modify
 something, select them and press enter.
 
+An alternative file to choose hostnames from can be specified by passing the location
+of the file as the first argument to the script.
+
 What about ports or other host-specific config?
 -----------------------------------------------
 

--- a/warp
+++ b/warp
@@ -61,7 +61,7 @@ warp() {
 # allow warp to be sourced without running
 if [[ $_ == $0 ]]; then
   # pass all arguments to the warp function
-  warp $@
+  warp "$@"
 else
   # Hide warp from history if using zsh and setopt histignorespace
   alias warp=" warp"

--- a/warp
+++ b/warp
@@ -1,8 +1,15 @@
 #!/bin/bash
 
 warp() {
+  
+  # use the first argument to specify an alternative warp file
+  if [ ! -z "$1" ]; then 
+    local SOURCE="$1"
+  else
+    local SOURCE="$HOME/.warp"
+  fi
+
   # ensure SOURCE file exists
-  local SOURCE="$HOME/.warp"
   if [ ! -f "$SOURCE" ]; then
     echo "$SOURCE does not exist..."
     return 1
@@ -56,7 +63,9 @@ warp() {
 
 # allow warp to be sourced without running
 if [[ $_ == $0 ]]; then
-  warp
+  # pass the first argument to the warp function
+  # so that it can be used as an alternate warp file
+  warp $1
 else
   # Hide warp from history if using zsh and setopt histignorespace
   alias warp=" warp"

--- a/warp
+++ b/warp
@@ -63,9 +63,8 @@ warp() {
 
 # allow warp to be sourced without running
 if [[ $_ == $0 ]]; then
-  # pass the first argument to the warp function
-  # so that it can be used as an alternate warp file
-  warp $1
+  # pass all arguments to the warp function
+  warp $@
 else
   # Hide warp from history if using zsh and setopt histignorespace
   alias warp=" warp"

--- a/warp
+++ b/warp
@@ -2,12 +2,9 @@
 
 warp() {
   
-  # use the first argument to specify an alternative warp file
-  if [ ! -z "$1" ]; then 
-    local SOURCE="$1"
-  else
-    local SOURCE="$HOME/.warp"
-  fi
+  # if a first argument is supplied, then use it as the warp file location
+  # otherwise, use the default "$HOME/.warp" location
+  local SOURCE="${1:-$HOME/.warp}"
 
   # ensure SOURCE file exists
   if [ ! -f "$SOURCE" ]; then


### PR DESCRIPTION
It could be useful to specify another warp file (perhaps, a system-wide warp file).  I made a small change to the script so that the first argument passed to the script is the location of the alternate warp file. 